### PR TITLE
Allow specifying version/time as part of keyprops

### DIFF
--- a/lib/AggregateWithKey.js
+++ b/lib/AggregateWithKey.js
@@ -60,7 +60,7 @@ AggregateWithKey.create = async function(props = {}, constructorParams) {
 AggregateWithKey._load = AggregateWithKey.load
 
 AggregateWithKey.load = async function(
-  keyProps,
+  {_time: time, _version: version, ...keyProps},
   {fail = false, ...constructorParams} = {}
 ) {
   const keyString =
@@ -69,7 +69,12 @@ AggregateWithKey.load = async function(
       : this.getKeyFromProps(keyProps).string
 
   const aggregateId = `${this.name}:${keyString}`
-  const instance = await this._load({...constructorParams, aggregateId})
+  const instance = await this._load({
+    ...constructorParams,
+    time,
+    version,
+    aggregateId,
+  })
 
   if (instance.version > 0) {
     return instance


### PR DESCRIPTION
Time or version can be specified as keyprops using `_time` or `_version`.

Example:

```js
User.load({userId: 'foobar', _version: 1})
User.load({userId: 'foobar'}, {version: 1})

User.load({userId: 'foobar', _time: new Date()})
User.load({userId: 'foobar'}, {time: new Date()})
```
