### PR TITLE
Support metadata in commits

### DIFF
--- a/lib/Aggregate.js
+++ b/lib/Aggregate.js
@@ -136,12 +136,13 @@ class Aggregate {
         const {Body: snapshotJSON} = await this.s3
           .getObject(this.snapshotS3Location)
           .promise()
-        const {state, version} = JSON.parse(snapshotJSON)
+        const {state, version, metadata} = JSON.parse(snapshotJSON)
 
         if (version > this.version) {
           this.logger.debug(`hydrate() found snapshot for version ${version}`)
           this._state = this.constructor.jsToState(state)
           this.version = version
+          this.metadata = metadata
         } else {
           this.logger.debug(
             `hydrate() snapshot version (${version}) older than ours (${this
@@ -241,7 +242,7 @@ class Aggregate {
     this.version = relevantCommits[relevantCommits.length - 1].version
   }
 
-  async commit(eventOrEvents, {retry = false} = {}) {
+  async commit(eventOrEvents, {retry = false, metadata = {}} = {}) {
     if (retry) {
       return this.retryWithHydration(() => this.commit(eventOrEvents))
     }
@@ -264,6 +265,7 @@ class Aggregate {
         version: {N: (this.version + 1).toString()},
         events: {S: JSON.stringify(events)},
         active: {S: 't'},
+        metadata: {S: JSON.stringify(metadata)},
       }
 
       await (this.batchWriter || this.ddb)
@@ -291,7 +293,7 @@ class Aggregate {
         await this.s3
           .putObject({
             ...this.snapshotS3Location,
-            Body: JSON.stringify({version, state}),
+            Body: JSON.stringify({version, state, metadata}),
           })
           .promise()
       }

--- a/lib/Aggregate.js
+++ b/lib/Aggregate.js
@@ -136,13 +136,12 @@ class Aggregate {
         const {Body: snapshotJSON} = await this.s3
           .getObject(this.snapshotS3Location)
           .promise()
-        const {state, version, metadata} = JSON.parse(snapshotJSON)
+        const {state, version} = JSON.parse(snapshotJSON)
 
         if (version > this.version) {
           this.logger.debug(`hydrate() found snapshot for version ${version}`)
           this._state = this.constructor.jsToState(state)
           this.version = version
-          this.metadata = metadata
         } else {
           this.logger.debug(
             `hydrate() snapshot version (${version}) older than ours (${this
@@ -293,7 +292,7 @@ class Aggregate {
         await this.s3
           .putObject({
             ...this.snapshotS3Location,
-            Body: JSON.stringify({version, state, metadata}),
+            Body: JSON.stringify({version, state}),
           })
           .promise()
       }

--- a/lib/utils/deserializeCommit.js
+++ b/lib/utils/deserializeCommit.js
@@ -4,7 +4,8 @@ function deserializeCommit(commit) {
     committedAt: new Date(parseInt(commit.committedAt.N, 10)),
     aggregateId: commit.aggregateId.S,
     version: parseInt(commit.version.N, 10),
-    events: JSON.parse(commit.events.S)
+    events: JSON.parse(commit.events.S),
+    metadata: JSON.parse(commit.metadata.S),
   }
 }
 


### PR DESCRIPTION
Added possibility to include arbitrary metadata on commits, useful for storing information about the user who created the commit, like userId, IP address, etc.
