### PR TITLE
allow async getKeyFromProps functions

### DIFF
--- a/lib/AggregateWithKey.js
+++ b/lib/AggregateWithKey.js
@@ -11,24 +11,24 @@ class AggregateWithKey extends Aggregate {
   ]
 }
 
-AggregateWithKey.getKeyFromProps = function(props) {
+AggregateWithKey.getKeyFromProps = async function(props) {
   if (typeof props === 'string') return props
 
-  const key = this.keyProperties.reduce((key, keyProp) => {
+  const key = {}
+  for (const keyProp of this.keyProperties) {
     const propKey = typeof keyProp === 'string' ? keyProp : keyProp.name
 
     if (typeof props[propKey] !== 'undefined') {
-      return {...key, [propKey]: props[propKey]}
-    }
-
-    if (typeof keyProp.defaultValue === 'function') {
-      return {...key, [propKey]: keyProp.defaultValue()}
+      key[propKey] = props[propKey]
+    } else if (typeof keyProp.defaultValue === 'function') {
+      key[propKey] = await keyProp.defaultValue.apply(this, [props])
     } else if (typeof keyProp.defaultValue !== undefined) {
-      return {...key, [propKey]: keyProp.defaultValue}
+      key[propKey] = keyProp.defaultValue
     }
-
-    throw new Error(`Empty id property: ${propKey}`)
-  }, {})
+    // else {
+    //   throw new Error(`Empty id property: ${propKey}`)
+    // }
+  }
 
   Object.defineProperty(key, 'string', {
     enumerable: false,
@@ -41,8 +41,7 @@ AggregateWithKey.getKeyFromProps = function(props) {
 }
 
 AggregateWithKey.create = async function(props = {}, constructorParams) {
-  const key = this.getKeyFromProps(props)
-
+  const key = await this.getKeyFromProps(props)
   const instance = new this({
     aggregateId: `${this.name}:${key.string}`,
     ...constructorParams,
@@ -70,7 +69,7 @@ AggregateWithKey.load = async function(
   } else {
     const {_time: time, _version: version, ...rest} = keyProps
     versionParams = {time, version}
-    keyString = this.getKeyFromProps(rest).string
+    keyString = (await this.getKeyFromProps(rest)).string
   }
 
   const aggregateId = `${this.name}:${keyString}`


### PR DESCRIPTION
This allows keyProperties to have async functions, like this:

```js
  static keyProperties = [
    'accountId',
    {
      name: 'jobId',
      async defaultValue({accountId}) {
        const {jobId, year} = await JobId.requestId(accountId)
        return `${year}-${jobId}`
      },
    },
  ]
```

@trym any thoughts?