### PR TITLE
Add Aggregate.getState()

### DIFF
--- a/lib/Aggregate.js
+++ b/lib/Aggregate.js
@@ -313,4 +313,10 @@ Aggregate.load = async function({version, time, ...constructorParams} = {}) {
   return aggregate
 }
 
+Aggregate.getState = async function(...args) {
+  const {state} = await this.load(...args)
+
+  return state
+}
+
 export default Aggregate

--- a/lib/AggregateWithKey.js
+++ b/lib/AggregateWithKey.js
@@ -97,4 +97,10 @@ AggregateWithKey.loadOrCreate = async function(...args) {
   return (await this.load(...args)) || (await this.create(...args))
 }
 
+AggregateWithKey.getState = async function(...args) {
+  const instance = await this.load(...args)
+
+  return instance && instance.state
+}
+
 export default AggregateWithKey


### PR DESCRIPTION
A common use-case is to just read the state of a given aggregate, hence adding it to ddbes would make its usage more practical.