### PR TITLE
Return null / fail for AWK.load() if state is empty

### DIFF
--- a/lib/AggregateWithKey.js
+++ b/lib/AggregateWithKey.js
@@ -80,7 +80,7 @@ AggregateWithKey.load = async function(
     aggregateId,
   })
 
-  if (instance.version > 0) {
+  if (instance.version > 0 && Object.keys(instance.state).length) {
     return instance
   }
 


### PR DESCRIPTION
This allows for "deleting" AggregateWithKey instances by making the state empty (have no keys).